### PR TITLE
Used optimized ALCs ...

### DIFF
--- a/src/main/java/edu/pitt/isg/dc/entry/LocationRule.java
+++ b/src/main/java/edu/pitt/isg/dc/entry/LocationRule.java
@@ -54,8 +54,8 @@ public class LocationRule {
             return Collections.emptySet();
 
         final Stream<String> stream = fields.stream().parallel();
-        final Set<EntryId> ids = filterEntryId(stream, alcs);
-        log.debug("LS: " + alcs +  "=>" + ids.size() + " entries:" + ids);
+        final Set<EntryId> ids = filterEntryId(stream, optimizedIds);
+        log.debug("LS: " + optimizedIds +  "=>" + ids.size() + " entries:" + ids);
         return ids;
     }
 


### PR DESCRIPTION
instead of all relevant ALCs to avoid too JDBC limitations of 32767 items (=Short.MAX_VALUE) in the IN clause.